### PR TITLE
Adds coverage/ dir to .gitignore and make clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ocb
 *.iml
 .idea/
 build/
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean:
 	rm -rf otel
 	rm -rf build
 	rm -rf ocb
+	rm -rf coverage
 
 
 check: test lint checkfmt coverage


### PR DESCRIPTION
When building locally, I noticed that there are untracked files that should be ignored.