### PR TITLE
Fix error attribute parsing and remove early returns

### DIFF
--- a/internal/lightstep_common/common.go
+++ b/internal/lightstep_common/common.go
@@ -2,6 +2,8 @@ package lightstep_common
 
 import (
 	"errors"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -24,4 +26,15 @@ type ProjectTraces struct {
 
 type OtelTransformer interface {
 	ToOtel() (*ProjectTraces, error)
+}
+
+func IsErrorAttributeValueActuallyError(value pcommon.Value) bool {
+	switch value.Type() {
+	case pcommon.ValueTypeBool:
+		return value.Bool()
+	case pcommon.ValueTypeStr:
+		return value.AsString() == "true"
+	default:
+		return false
+	}
 }

--- a/internal/lightstep_pb/transform_test.go
+++ b/internal/lightstep_pb/transform_test.go
@@ -2,6 +2,8 @@ package lightstep_pb
 
 import (
 	"context"
+	"testing"
+
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/matryer/is"
 	"go.opentelemetry.io/collector/component"
@@ -10,9 +12,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/zap"
-	"testing"
 
-	lightstepCommon "github.com/zalando/otelcol-lightstep-receiver/internal/lightstep_common"
 	pb "github.com/zalando/otelcol-lightstep-receiver/internal/lightstep_pb/collectorpb"
 	"github.com/zalando/otelcol-lightstep-receiver/internal/telemetry"
 )
@@ -181,7 +181,7 @@ func TestTransformation_NoServiceName(t *testing.T) {
 		telemetry: initTelemetry(),
 	}
 	_, err := rq.ToOtel(context.Background())
-	is.Equal(err, lightstepCommon.ErrNoServiceName)
+	is.Equal(err, nil)
 }
 
 func TestTransformation_NoAccessToken(t *testing.T) {
@@ -198,7 +198,7 @@ func TestTransformation_NoAccessToken(t *testing.T) {
 		telemetry: initTelemetry(),
 	}
 	_, err := rq.ToOtel(context.Background())
-	is.Equal(err, lightstepCommon.ErrNoAccessToken)
+	is.Equal(err, nil)
 }
 
 func TestTransformation_GetClientDropSpans(t *testing.T) {


### PR DESCRIPTION
1. Set span error based on error attribute value
2. Remove early returns from `ToOtel` functions