### PR TITLE
Fixed a problem with missing or inconsistent timestamps in responses

### DIFF
--- a/internal/lightstep_pb/grpc/server.go
+++ b/internal/lightstep_pb/grpc/server.go
@@ -3,8 +3,10 @@ package grpc
 import (
 	"context"
 	"errors"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"net"
 	"sync"
+	"time"
 
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/config/configgrpc"
@@ -93,7 +95,7 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 		spanCount     int
 	)
 	ctx = client.NewContext(ctx, client.Info{})
-
+	receivedAt := time.Now()
 	ctx = s.obsreport.StartTracesOp(ctx)
 	spanCount = len(rq.Spans)
 	s.logger.Debug("report", zap.Any("incoming", rq))
@@ -101,7 +103,9 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 	if projectTraces, err = lr.ToOtel(ctx); err != nil {
 		s.telemetry.IncrementFailed(transport, 1)
 		return &pb.ReportResponse{
-			Errors: []string{err.Error()},
+			Errors:            []string{err.Error()},
+			ReceiveTimestamp:  timestamppb.New(receivedAt),
+			TransmitTimestamp: timestamppb.Now(),
 		}, err
 	}
 	s.telemetry.IncrementProcessed(transport, 1)
@@ -118,11 +122,15 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 
 	if err != nil {
 		return &pb.ReportResponse{
-			Errors: []string{err.Error()},
+			Errors:            []string{err.Error()},
+			ReceiveTimestamp:  timestamppb.New(receivedAt),
+			TransmitTimestamp: timestamppb.Now(),
 		}, err
 	}
 
 	return &pb.ReportResponse{
-		Errors: nil,
+		Errors:            nil,
+		ReceiveTimestamp:  timestamppb.New(receivedAt),
+		TransmitTimestamp: timestamppb.Now(),
 	}, nil
 }

--- a/internal/lightstep_pb/grpc/server.go
+++ b/internal/lightstep_pb/grpc/server.go
@@ -95,7 +95,7 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 		spanCount     int
 	)
 	ctx = client.NewContext(ctx, client.Info{})
-	receivedAt := time.Now()
+	receiveTimestamp := time.Now()
 	ctx = s.obsreport.StartTracesOp(ctx)
 	spanCount = len(rq.Spans)
 	s.logger.Debug("report", zap.Any("incoming", rq))
@@ -104,7 +104,7 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 		s.telemetry.IncrementFailed(transport, 1)
 		return &pb.ReportResponse{
 			Errors:            []string{err.Error()},
-			ReceiveTimestamp:  timestamppb.New(receivedAt),
+			ReceiveTimestamp:  timestamppb.New(receiveTimestamp),
 			TransmitTimestamp: timestamppb.Now(),
 		}, err
 	}
@@ -123,14 +123,14 @@ func (s *ServerGRPC) Report(ctx context.Context, rq *pb.ReportRequest) (*pb.Repo
 	if err != nil {
 		return &pb.ReportResponse{
 			Errors:            []string{err.Error()},
-			ReceiveTimestamp:  timestamppb.New(receivedAt),
+			ReceiveTimestamp:  timestamppb.New(receiveTimestamp),
 			TransmitTimestamp: timestamppb.Now(),
 		}, err
 	}
 
 	return &pb.ReportResponse{
 		Errors:            nil,
-		ReceiveTimestamp:  timestamppb.New(receivedAt),
+		ReceiveTimestamp:  timestamppb.New(receiveTimestamp),
 		TransmitTimestamp: timestamppb.Now(),
 	}, nil
 }

--- a/internal/lightstep_thrift/reporter.go
+++ b/internal/lightstep_thrift/reporter.go
@@ -14,10 +14,11 @@ import (
 
 // ThriftServerReportRequest defines thrift report request with http context
 type ThriftServerReportRequest struct {
-	context    context.Context
-	obsreport  *receiverhelper.ObsReport
-	nextTraces consumer.Traces
-	telemetry  *telemetry.Telemetry
+	receiveTimestamp int64
+	context          context.Context
+	obsreport        *receiverhelper.ObsReport
+	nextTraces       consumer.Traces
+	telemetry        *telemetry.Telemetry
 }
 
 func (tsr *ThriftServerReportRequest) getFormatFromContext() string {
@@ -66,7 +67,7 @@ func (tsr *ThriftServerReportRequest) newReportResponse(err error) *collectorthr
 	res := &collectorthrift.ReportResponse{
 		Commands: nil,
 		Timing: &collectorthrift.Timing{
-			ReceiveMicros:  &now,
+			ReceiveMicros:  &tsr.receiveTimestamp,
 			TransmitMicros: &now,
 		},
 	}

--- a/internal/lightstep_thrift/server.go
+++ b/internal/lightstep_thrift/server.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	lightstepConstants "github.com/lightstep/lightstep-tracer-go/constants"
@@ -157,10 +158,11 @@ func (ts *ThriftServer) HandleThriftBinaryRequest(w http.ResponseWriter, rq *htt
 	oprot := thrift.NewTBinaryProtocolTransport(transp)
 
 	tsr := &ThriftServerReportRequest{
-		context:    ctx,
-		obsreport:  ts.obsreport,
-		nextTraces: ts.nextTraces,
-		telemetry:  ts.telemetry,
+		context:          ctx,
+		obsreport:        ts.obsreport,
+		nextTraces:       ts.nextTraces,
+		telemetry:        ts.telemetry,
+		receiveTimestamp: time.Now().UnixMicro(),
 	}
 
 	if err != nil {
@@ -198,10 +200,11 @@ func (ts *ThriftServer) HandleThriftJSONRequestV0(w http.ResponseWriter, rq *htt
 	})
 
 	tsr := &ThriftServerReportRequest{
-		context:    ctx,
-		obsreport:  ts.obsreport,
-		nextTraces: ts.nextTraces,
-		telemetry:  ts.telemetry,
+		context:          ctx,
+		obsreport:        ts.obsreport,
+		nextTraces:       ts.nextTraces,
+		telemetry:        ts.telemetry,
+		receiveTimestamp: time.Now().UnixMicro(),
 	}
 
 	switch rq.Header.Get("Content-Encoding") {


### PR DESCRIPTION
This PR fixes missing or inconsistent timestamps in responses, in particular solving the java-tracer problem  `Collector response did not include timing info` which causes blocking any further tracing transmission

